### PR TITLE
trigger community-theme-tutor on every push to gradebook

### DIFF
--- a/.github/workflows/tutor.yml
+++ b/.github/workflows/tutor.yml
@@ -1,0 +1,14 @@
+name: Build and deploy tutor
+on: push
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: trigger community-tutor workflow
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.ORG_ACCESS_TOKEN }}" \
+          https://api.github.com/repos/Abstract-Tech/community-theme-tutor/actions/workflows/tutor.yml/dispatches -d '{"ref":"main"}'


### PR DESCRIPTION
This PR contains a workflow that manually triggger the community-theme-tutor. When a developer will push anythin ghere at gradebook. The main community-theme-tutor workflow will be triggered to build again MFEs and Openedx.